### PR TITLE
Remove unnecessary exit

### DIFF
--- a/01-RunDockerImage/README.md
+++ b/01-RunDockerImage/README.md
@@ -63,9 +63,6 @@ docker ps
 docker kill <container id>
 docker ps
 docker ps -a
-
-# Exit the container
-exit
 ```
 
 ## Pull an Ubuntu Image


### PR DESCRIPTION
No need to exit because we don't have an interactive terminal open to the container