### PR TITLE
05-Linking: Run nginx-app in the background

### DIFF
--- a/05-Linking/README.md
+++ b/05-Linking/README.md
@@ -26,7 +26,7 @@ Let's start up a new container with nginx in it that will proxy through
 to our node app.
 
 ```bash
-docker run -it -p 8080:8888 --link <node container id>:app nginx-app
+docker run -d -p 8080:8888 --link <node container id>:app nginx-app
 ```
 
 - Preview the running application


### PR DESCRIPTION
I think the `-it` when running the nginx-app container was a typo, it should be `-d` to run in the background.